### PR TITLE
fixing bug for not showing median graph when maxValues is 0

### DIFF
--- a/src/sections/PerformanceRadar/PIP/index.jsx
+++ b/src/sections/PerformanceRadar/PIP/index.jsx
@@ -30,7 +30,7 @@ const cleanMap = ([category, { maxValues, averages, variations, percentages, num
   category,
   value: `(máx atribuição ${maxValues})`, // variations == null || variations === -1 ? '—' : formatPercent(variations),
   isAboveAverage: null, // variations == null || variations === -1 ? null : variations >= 0,
-  median: 100 * (averages / maxValues),
+  median: 100 * (averages / (maxValues || 1)),
   x: category,
   y: percentages * 100,
   numbers,

--- a/src/sections/PerformanceRadar/RadarCommon.jsx
+++ b/src/sections/PerformanceRadar/RadarCommon.jsx
@@ -29,6 +29,7 @@ class PerformanceRadar extends React.Component {
 
   cleanGraphData(data) {
     const { cleanMap } = this.props;
+
     const chartData = Object.entries(data)
       .filter(cat => cat[0] !== 'meta')
       .map(cleanMap);

--- a/src/sections/PerformanceRadar/Tutela/index.jsx
+++ b/src/sections/PerformanceRadar/Tutela/index.jsx
@@ -30,7 +30,7 @@ const cleanMap = ([category, { maxValues, averages, variations, percentages, num
   category,
   value: `(máx atribuição ${maxValues})`, // variations == null || variations === -1 ? '—' : formatPercent(variations),
   isAboveAverage: null, // variations == null || variations === -1 ? null : variations >= 0,
-  median: 100 * (averages / maxValues),
+  median: 100 * (averages / (maxValues || 1)),
   x: category,
   y: percentages * 100,
   numbers,


### PR DESCRIPTION
Na promotoria de Dr. Cristiane o valor máximo da TAC é zero. Isso força uma divisão por zero que causa um NaN que quebra o gráfico.

Esse patch resolve esse problema forçando uma divisão por 1 nesses casos na hora de calcular a median da aresta.