### PR TITLE
Bugfix/infinito sua mesa

### DIFF
--- a/src/dashboard/sections/YourDesk/GenericTab/MetricsFormatter.jsx
+++ b/src/dashboard/sections/YourDesk/GenericTab/MetricsFormatter.jsx
@@ -33,7 +33,8 @@ function courtCasesMetrics({
       <strong> Houve
         {variacao60Dias >= 0 ? ` aumento de ${monthVariation} ` : ` redução de ${monthVariation} `}
        </strong>
-      com relação ao mesmo período anterior.
+      com relação ao mesmo período anterior, quando foram ajuizadas
+      <strong>{` ${nrAcoes60DiasAnterior} ${nrAcoes60DiasAnterior === 1 ? 'ação' : 'ações'}.`}</strong>
       <p>
         No último ano, você ajuizou
         <strong>{` ${nrAcoes12MesesAtual} ${nrAcoes12MesesAtual === 1 ? 'ação' : 'ações'}`}</strong>


### PR DESCRIPTION
Fix pull/223 {variacao60Dias} and improved text based on Promotrello Card #129.

I can't include "em comparação com o ano anterior, em que N ações foram ajuizadas." because previous value isn't avaiable in scope.