### PR TITLE
Feature/alerta ctac complete

### DIFF
--- a/src/api/endpoints.js
+++ b/src/api/endpoints.js
@@ -78,6 +78,9 @@ export const ABR1_ALERT_ACTION = t(
 
 export const ALERT_OVERLAY_DATA = t(`${BASE_URL}/alertas/overlay/\${docDk}`);
 
+export const CTAC_ACTION_GENERATE_DOC = t(
+  `${BASE_URL}/documentos/comunicacao-tac/\${orgao}/\${cpf}/\${docDk}?jwt=\${token}`
+);
 export const IC1A_ACTION_GENERATE_DOC = t(
   `${BASE_URL}/documentos/prorrogacao-ic/\${orgao}/\${cpf}/\${docDk}?jwt=\${token}`,
 );

--- a/src/dashboard/sections/Alerts/AlertsOverlay/index.jsx
+++ b/src/dashboard/sections/Alerts/AlertsOverlay/index.jsx
@@ -5,7 +5,7 @@ import { useAuth } from '../../../../app/authContext';
 import { Spinner } from '../../../../components';
 
 import './styles.css';
-import { OVERLAY_TEXTS, PRCR_TEXTS, IC1A_TEXT } from './overlayConstants';
+import { OVERLAY_TEXTS, PRCR_TEXTS, IC1A_TEXT, PA1A_TEXT } from './overlayConstants';
 
 const propTypes = {
   type: PropTypes.string.isRequired,
@@ -55,7 +55,7 @@ function AlertsOverlay({ type, setShowOverlay, children, docDk }) {
           break;
         case 'PA1A':
           data = await getOverlayText(type, docDk);
-          texts = IC1A_TEXT(data);
+          texts = PA1A_TEXT(data);
           break;
         default:
           texts = <p>{`Os dados para alertas ${type} ainda não estão disponíveis`}</p>;

--- a/src/dashboard/sections/Alerts/AlertsOverlay/overlayConstants.jsx
+++ b/src/dashboard/sections/Alerts/AlertsOverlay/overlayConstants.jsx
@@ -155,6 +155,31 @@ export const OVERLAY_TEXTS = {
       trabalho de controle externo da polícia.
     </p>
   ),
+  CTAC: (
+    <div>
+      <p>
+        Neste alerta, eu busco lhe informar de procedimentos que tiveram TACs celebrados, sem a devida
+        comunicação ao Conselho Superior do Ministério Público.
+      </p>
+
+      <p />
+
+      <p>
+        Para verificar isso, eu procuro no sistema todos os procedimentos que tiveram andamentos de TAC
+        realizados. Em seguida, verifico se todos tiveram andamento de Ciência de Decisão do CSMP, ou
+        de Ofício cujo destinatário tenha sido preenchido com "CSMP" ou "Conselho Superior do Ministério
+        Público", posterior ao TAC.
+        Caso algum desses procedimentos não se encontre dentro desses critérios, eu o aviso desse fato.
+      </p>
+
+      <p />
+
+      <p>
+        Para desativar este alerta, basta realizar um andamento de Ofício neste procedimento, preenchendo
+        o campo destinatário com "CSMP".
+      </p>
+    </div>
+  ),
 };
 
 export const PRCR_TEXTS = (type, data) => {

--- a/src/dashboard/sections/Alerts/utils/individualAlertFormatter.jsx
+++ b/src/dashboard/sections/Alerts/utils/individualAlertFormatter.jsx
@@ -20,6 +20,7 @@ import {
 import {
   PRCR_ACTION_GENERATE_DOC,
   COMPRAS_ACTION_OUVIDORIA,
+  CTAC_ACTION_GENERATE_DOC,
   IC1A_ACTION_GENERATE_DOC,
   PPFP_ACTION_EXTEND,
   PPFP_ACTION_CONVERT,
@@ -139,7 +140,7 @@ export default function individualAlertFormatter(alert, cpf, token, orgao) {
       return dt2iConstructor(alert, orgao, cpf, token);
 
     case 'CTAC':
-      return ctacConstructor(alert);
+      return ctacConstructor(alert, orgao, cpf, token);
 
     case 'FEBT':
       return febtConstructor(alert);
@@ -910,7 +911,7 @@ function roOccurrence(alert, orgao, cpf, token) {
   };
 }
 
-function ctacConstructor({ dropdown, alertCode, count, docNum, alertId }) {
+function ctacConstructor({ dropdown, alertCode, count, docNum, docDk, alertId }, orgao, cpf, token) {
   const key = alertId ? alertId : `${alertCode}-dropdown`;
   let message;
   let actions = [];
@@ -919,18 +920,22 @@ function ctacConstructor({ dropdown, alertCode, count, docNum, alertId }) {
     const single = count === 1;
     message = (
       <span>
-        <strong>{`Você celebrou ${count} ${single ? 'tac' : 'tacs'} `}</strong>
-        no procedimento <strong> xxx </strong> e ainda não comunicou ao conselho Superior do
-        Ministerio Público.
+        Você <strong>celebrou TAC</strong> em <strong>{`${count}`}</strong> {`${single ? 'procedimento ' : 'procedimentos '}`}
+        e ainda <strong>não comunicou ao conselho Superior do
+        Ministerio Público.</strong>
       </span>
     );
   } else {
-    actions = [DETAIL(), DELETE];
+    actions = [
+      GENERATE_MINUTA(CTAC_ACTION_GENERATE_DOC({ orgao, token, docDk, cpf })),
+      DETAIL(),
+      DELETE,
+    ];
     message = (
       <span>
-        <strong>{`Você celebrou ${count} ${single ? 'tac' : 'tacs'} `}</strong>
-        no procedimento <strong> xxx </strong> e ainda não comunicou ao conselho Superior do
-        Ministerio Público.
+        Você <strong>celebrou um TAC </strong>
+        no procedimento <strong>{`${docNum}`}</strong> e ainda <strong>não comunicou ao conselho Superior do
+        Ministerio Público.</strong>
       </span>
     );
   }
@@ -939,7 +944,7 @@ function ctacConstructor({ dropdown, alertCode, count, docNum, alertId }) {
     actions,
     backgroundColor: '#F86C72',
     backgroundColorChild: '#D94F55',
-    icon: <Clock />,
+    icon: <ClockIcon />,
     key,
     message,
   };


### PR DESCRIPTION
Adds endpoint to the CTAC alert document generator. Also adds text for the CTAC alert overlay, and a few other corrections.

Additionally, corrects a bug that called "IC1A _TEXT" instead of "PA1A_TEXT" when building the PA1A alert overlay.